### PR TITLE
OPS-213 GHActions: Update JS projects to include Node 16

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,7 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [ '10', '12', '14' ]
+        node: [ '12', '14', '16' ]
+
     name: Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * [TT-8892] Migrate to github actions
+* [OPS-213] GHActions: add Node 16 and remove Node 10
 
 ## 0.1.2
 


### PR DESCRIPTION
**Why:**
Add Node 16 and remove Node 10 in Github Action.

**How To Test:**
See the Action succeeded.